### PR TITLE
change-demo-light-search-engine-option

### DIFF
--- a/frontend/demo_light/demo_util.py
+++ b/frontend/demo_light/demo_util.py
@@ -514,13 +514,13 @@ def set_storm_runner():
         search_top_k=3,
         retrieve_top_k=5
     )
-
+    
     if st.secrets['RETRIEVER'] == 'bing':
-        rm = BingSearch(bing_search_api=st.secrets['API_KEY'], k=engine_args.search_top_k)
+        rm = BingSearch(bing_search_api=st.secrets['BING_SEARCH_API_KEY'], k=engine_args.search_top_k)
     elif st.secrets['RETRIEVER'] == 'you':
-        rm = YouRM(ydc_api_key=st.secrets['API_KEY'], k=engine_args.search_top_k)
+        rm = YouRM(ydc_api_key=st.secrets['YDC_API_KEY'], k=engine_args.search_top_k)
     elif st.secrets['RETRIEVER'] == 'brave':
-        rm = BraveRM(brave_search_api_key=st.secrets['API_KEY'], k=engine_args.search_top_k)
+        rm = BraveRM(brave_search_api_key=st.secrets['BRAVE_SEARCH_API_KEY'], k=engine_args.search_top_k)
 
     runner = STORMWikiRunner(engine_args, llm_configs, rm)
     st.session_state["runner"] = runner

--- a/frontend/demo_light/demo_util.py
+++ b/frontend/demo_light/demo_util.py
@@ -15,7 +15,7 @@ import streamlit as st
 # sys.path.append('../../')
 from knowledge_storm import STORMWikiRunnerArguments, STORMWikiRunner, STORMWikiLMConfigs
 from knowledge_storm.lm import OpenAIModel
-from knowledge_storm.rm import YouRM
+from knowledge_storm.rm import YouRM, BingSearch, BraveRM
 from knowledge_storm.storm_wiki.modules.callback import BaseCallbackHandler
 from stoc import stoc
 
@@ -515,7 +515,12 @@ def set_storm_runner():
         retrieve_top_k=5
     )
 
-    rm = YouRM(ydc_api_key=st.secrets['YDC_API_KEY'], k=engine_args.search_top_k)
+    if st.secrets['RETRIEVER'] == 'bing':
+        rm = BingSearch(bing_search_api=st.secrets['API_KEY'], k=engine_args.search_top_k)
+    elif st.secrets['RETRIEVER'] == 'you':
+        rm = YouRM(ydc_api_key=st.secrets['API_KEY'], k=engine_args.search_top_k)
+    elif st.secrets['RETRIEVER'] == 'brave':
+        rm = BraveRM(brave_search_api_key=st.secrets['API_KEY'], k=engine_args.search_top_k)
 
     runner = STORMWikiRunner(engine_args, llm_configs, rm)
     st.session_state["runner"] = runner

--- a/frontend/demo_light/requirements.txt
+++ b/frontend/demo_light/requirements.txt
@@ -1,5 +1,6 @@
 streamlit==1.31.1
 streamlit-card
+knowledge_storm
 markdown
 unidecode
 extra-streamlit-components==0.1.60
@@ -8,3 +9,4 @@ deprecation==2.1.0
 st-pages==0.4.5
 streamlit-float
 streamlit-option-menu
+toml

--- a/frontend/demo_light/requirements.txt
+++ b/frontend/demo_light/requirements.txt
@@ -1,6 +1,5 @@
 streamlit==1.31.1
 streamlit-card
-knowledge_storm
 markdown
 unidecode
 extra-streamlit-components==0.1.60
@@ -9,4 +8,12 @@ deprecation==2.1.0
 st-pages==0.4.5
 streamlit-float
 streamlit-option-menu
+dspy_ai==2.4.9
+wikipedia==1.4.0
+sentence_transformers
 toml
+langchain-text-splitters
+trafilatura
+langchain-huggingface
+qdrant-client
+langchain-qdrant


### PR DESCRIPTION
This pull request includes updates to the `frontend/demo_light/demo_util.py` file to enhance the flexibility of the search retriever configuration. The most important changes are the addition of new retriever options and the corresponding logic to select the appropriate retriever based on a configuration setting.

Enhancements to search retriever configuration:

* [`frontend/demo_light/demo_util.py`](diffhunk://#diff-ca774f4099ddd8b1de979f39ffe50c4a5e05faf5f64b590467d80e66833c9a5cL18-R18): Added imports for `BingSearch` and `BraveRM` to support new retriever options.
* [`frontend/demo_light/demo_util.py`](diffhunk://#diff-ca774f4099ddd8b1de979f39ffe50c4a5e05faf5f64b590467d80e66833c9a5cL518-R523): Modified the `set_storm_runner` function to include conditional logic for selecting the retriever based on the `RETRIEVER` configuration setting, allowing the use of `BingSearch`, `YouRM`, or `BraveRM`.